### PR TITLE
Update weather location debug print statement to match ArduinoJson 6.20 API

### DIFF
--- a/weather.cpp
+++ b/weather.cpp
@@ -282,7 +282,7 @@ OwmResult refreshWeather()
             }
             latitude = result["lat"].as<float>();
             longitude = result["lon"].as<float>();
-            DEBUG_PRINT("Found location %s, %s @ %0.6f,%0.6f", result["name"].as<char*>(), result["country"].as<char*>(), latitude, longitude);
+            DEBUG_PRINT("Found location %s, %s @ %0.6f,%0.6f", result["name"].as<const char*>(), result["country"].as<const char*>(), latitude, longitude);
         } else {
             http.end();
             DEBUG_PRINT("Request to openweathermap failed with %d after %lums", status, millis() - start);


### PR DESCRIPTION
Turning on `DEBUG` in `config.h` led to this error when compiling 


```
❯ arduino-cli compile --clean -b 'esp32:esp32:esp32' -p /dev/ttyUSB0 -u --optimize-for-debug portal_calendar.ino
/home/chris/projects/portal_calendar/portal_calendar.ino: In function 'void setup()':
/home/chris/projects/portal_calendar/portal_calendar.ino:293:17: error: 'errorInvalidOwmLocation' was not declared in this scope
                 errorInvalidOwmLocation();
                 ^~~~~~~~~~~~~~~~~~~~~~~
/home/chris/projects/portal_calendar/portal_calendar.ino:293:17: note: suggested alternative: 'errorInvalidOwmApiKey'
                 errorInvalidOwmLocation();
                 ^~~~~~~~~~~~~~~~~~~~~~~
                 errorInvalidOwmApiKey
In file included from /home/chris/projects/portal_calendar/weather.h:1,
                 from /home/chris/projects/portal_calendar/weather.cpp:3:
/home/chris/projects/portal_calendar/weather.cpp: In function 'OwmResult refreshWeather()':
/home/chris/projects/portal_calendar/weather.cpp:256:49: error: expected ')' before 'WEATHER_LOCATION'
         DEBUG_PRINT("Looking up lat,long for '" WEATHER_LOCATION "' from openweathermap");
                                                 ^~~~~~~~~~~~~~~~
/home/chris/projects/portal_calendar/global.h:8:40: note: in definition of macro 'DEBUG_PRINT'
 #define DEBUG_PRINT(...) Serial.printf(__VA_ARGS__); Serial.print('\n')
                                        ^~~~~~~~~~~
/home/chris/projects/portal_calendar/global.h:8:39: note: to match this '('
 #define DEBUG_PRINT(...) Serial.printf(__VA_ARGS__); Serial.print('\n')
                                       ^
/home/chris/projects/portal_calendar/weather.cpp:256:9: note: in expansion of macro 'DEBUG_PRINT'
         DEBUG_PRINT("Looking up lat,long for '" WEATHER_LOCATION "' from openweathermap");
         ^~~~~~~~~~~
/home/chris/projects/portal_calendar/weather.cpp:263:23: error: 'WEATHER_LOCATION' was not declared in this scope
             urlEncode(WEATHER_LOCATION).c_str(),
                       ^~~~~~~~~~~~~~~~
/home/chris/projects/portal_calendar/weather.cpp:263:23: note: suggested alternative: 'WEATHER_UNITS'
             urlEncode(WEATHER_LOCATION).c_str(),
                       ^~~~~~~~~~~~~~~~
                       WEATHER_UNITS
In file included from /home/chris/projects/portal_calendar/weather.h:1,
                 from /home/chris/projects/portal_calendar/weather.cpp:3:
/home/chris/projects/portal_calendar/weather.cpp:285:89: error: no matching function for call to 'ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*>::as<char*>()'
             DEBUG_PRINT("Found location %s, %s @ %0.6f,%0.6f", result["name"].as<char*>(), result["country"].as<char*>(), latitude, longitude);
                                                                                         ^
/home/chris/projects/portal_calendar/global.h:8:40: note: in definition of macro 'DEBUG_PRINT'
 #define DEBUG_PRINT(...) Serial.printf(__VA_ARGS__); Serial.print('\n')
                                        ^~~~~~~~~~~
In file included from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Array/ElementProxy.hpp:7,
                 from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Array/JsonArray.hpp:7,
                 from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson.hpp:24,
                 from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson.h:9,
                 from /home/chris/projects/portal_calendar/weather.cpp:2:
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:53:3: note: candidate: 'template<class T> typename ArduinoJson6200_F1::enable_if<(((! ArduinoJson6200_F1::is_same<T, char*>::value) && (! ArduinoJson6200_F1::is_same<T, char>::value)) && (! ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value)), T>::type ArduinoJson6200_F1::VariantRefBase<TDerived>::as() const [with T = T; TDerived = ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*>]'
   as() const {
   ^~
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:53:3: note:   template argument deduction/substitution failed:
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp: In substitution of 'template<class T> typename ArduinoJson6200_F1::enable_if<(((! ArduinoJson6200_F1::is_same<T, char*>::value) && (! ArduinoJson6200_F1::is_same<T, char>::value)) && (! ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value)), T>::type ArduinoJson6200_F1::VariantRefBase<ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*> >::as<T>() const [with T = char*]':
/home/chris/projects/portal_calendar/weather.cpp:285:13:   required from here
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:53:3: error: no type named 'type' in 'struct ArduinoJson6200_F1::enable_if<false, char*>'
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:61:3: note: candidate: 'template<class T> typename ArduinoJson6200_F1::enable_if<ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value, T>::type ArduinoJson6200_F1::VariantRefBase<TDerived>::as() const [with T = T; TDerived = ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*>]'
   as() const {
   ^~
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:61:3: note:   template argument deduction/substitution failed:
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp: In substitution of 'template<class T> typename ArduinoJson6200_F1::enable_if<ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value, T>::type ArduinoJson6200_F1::VariantRefBase<ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*> >::as<T>() const [with T = char*]':
/home/chris/projects/portal_calendar/weather.cpp:285:13:   required from here
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:61:3: error: no type named 'type' in 'struct ArduinoJson6200_F1::enable_if<false, char*>'
In file included from /home/chris/projects/portal_calendar/weather.h:1,
                 from /home/chris/projects/portal_calendar/weather.cpp:3:
/home/chris/projects/portal_calendar/weather.cpp:285:120: error: no matching function for call to 'ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*>::as<char*>()'
             DEBUG_PRINT("Found location %s, %s @ %0.6f,%0.6f", result["name"].as<char*>(), result["country"].as<char*>(), latitude, longitude);
                                                                                                                        ^
/home/chris/projects/portal_calendar/global.h:8:40: note: in definition of macro 'DEBUG_PRINT'
 #define DEBUG_PRINT(...) Serial.printf(__VA_ARGS__); Serial.print('\n')
                                        ^~~~~~~~~~~
In file included from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Array/ElementProxy.hpp:7,
                 from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Array/JsonArray.hpp:7,
                 from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson.hpp:24,
                 from /home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson.h:9,
                 from /home/chris/projects/portal_calendar/weather.cpp:2:
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:53:3: note: candidate: 'template<class T> typename ArduinoJson6200_F1::enable_if<(((! ArduinoJson6200_F1::is_same<T, char*>::value) && (! ArduinoJson6200_F1::is_same<T, char>::value)) && (! ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value)), T>::type ArduinoJson6200_F1::VariantRefBase<TDerived>::as() const [with T = T; TDerived = ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*>]'
   as() const {
   ^~
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:53:3: note:   template argument deduction/substitution failed:
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp: In substitution of 'template<class T> typename ArduinoJson6200_F1::enable_if<(((! ArduinoJson6200_F1::is_same<T, char*>::value) && (! ArduinoJson6200_F1::is_same<T, char>::value)) && (! ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value)), T>::type ArduinoJson6200_F1::VariantRefBase<ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*> >::as<T>() const [with T = char*]':
/home/chris/projects/portal_calendar/weather.cpp:285:13:   required from here
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:53:3: error: no type named 'type' in 'struct ArduinoJson6200_F1::enable_if<false, char*>'
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:61:3: note: candidate: 'template<class T> typename ArduinoJson6200_F1::enable_if<ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value, T>::type ArduinoJson6200_F1::VariantRefBase<TDerived>::as() const [with T = T; TDerived = ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*>]'
   as() const {
   ^~
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:61:3: note:   template argument deduction/substitution failed:
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp: In substitution of 'template<class T> typename ArduinoJson6200_F1::enable_if<ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value, T>::type ArduinoJson6200_F1::VariantRefBase<ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonVariant, const char*> >::as<T>() const [with T = char*]':
/home/chris/projects/portal_calendar/weather.cpp:285:13:   required from here
/home/chris/Arduino/libraries/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:61:3: error: no type named 'type' in 'struct ArduinoJson6200_F1::enable_if<false, char*>'
```

Looking at https://arduinojson.org/v6/api/jsonvariantconst/as/ it appears that `as<char*>()` was removed in 6.20.

I nievely swapped it to `as<const char*>()` and it compiled for me. I don't know if this is a correct and proper fix but it did appear t work. 

If there is a more proper soltuion please advise and I will happy update the PR 