### PR TITLE
Removed useless DEBUG_DELAY

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,6 @@ src_dir = .
 framework = arduino
 lib_deps =
 	bblanchon/ArduinoJson@^6.20.0
-build_flags = -D DEBUG_DELAY=4000
 
 monitor_speed = 115200
 

--- a/portal_calendar.ino
+++ b/portal_calendar.ino
@@ -219,9 +219,6 @@ void setup()
     #ifdef DEBUG
     time(&t);
     Serial.begin(115200);
-    #if(defined PLATFORMIO && defined DEBUG_DELAY)
-        delay(DEBUG_DELAY);
-    #endif
     localtime_r(&t, &now);
     char timestr[30];
     strftime(timestr, sizeof(timestr), "%d-%m-%Y %H:%M:%S", &now);


### PR DESCRIPTION
In response to https://github.com/wuspy/portal_calendar/pull/9#discussion_r1118002653:
There's no other brick-faced developer like me.

Did not know about the "Upload and Monitor" as it wasn't in my status-bar... shame on me.
Found it in Pio->Tasks and works exactly as expected.