### PR TITLE
Allow hosthame

### DIFF
--- a/config.h
+++ b/config.h
@@ -4,6 +4,7 @@
  */
 #define WIFI_NAME "your wifi name here"
 #define WIFI_PASS "your wifi password here"
+#define HOSTNAME "portal_calendar"
 
 /**
  * Show the day name on the right side (next to the XX/XX day)

--- a/portal_calendar.ino
+++ b/portal_calendar.ino
@@ -84,7 +84,10 @@ bool startWifi()
     if (WiFi.status() == WL_CONNECTED) {
         return true;
     }
-    DEBUG_PRINT("Starting WiFi");
+    
+    DEBUG_PRINT("Starting WiFi with hostname %s", HOSTNAME);
+    WiFi.setHostname(HOSTNAME);
+
     unsigned long start = millis();
     #ifdef WIFI_PASS
     WiFi.begin(WIFI_NAME, WIFI_PASS);


### PR DESCRIPTION
Allow a hostname to be sent to DHCP. This avoids a generic "esp" hostname. 

A sane default of `portal_calendar` is specified, and is non-optional (which seems like it shouldn't be an issue) 

Toward https://github.com/wuspy/portal_calendar/issues/8