### PR TITLE
Allow SPI pins to be specified

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -294,7 +294,7 @@ Display::~Display()
 void Display::init()
 {
     if (!_display) {
-        _display = new DisplayGDEW075T7(SPI_BUS, CS_PIN, RESET_PIN, DC_PIN, BUSY_PIN);
+        _display = new DisplayGDEW075T7(SPI_BUS, CLK_PIN, DIN_PIN, CS_PIN, RESET_PIN, DC_PIN, BUSY_PIN);
         _display->setRotation(DisplayGDEW075T7::ROTATION_270);
         _display->setAlpha(DisplayGDEW075T7::WHITE);
     } else {

--- a/DisplayGDEW075T7.cpp
+++ b/DisplayGDEW075T7.cpp
@@ -212,7 +212,7 @@ DisplayGDEW075T7::~DisplayGDEW075T7() {
     delete[] _frameBuffer;
 };
 
-DisplayGDEW075T7::DisplayGDEW075T7(uint8_t spi_bus, uint8_t cs_pin, uint8_t reset_pin, uint8_t dc_pin, uint8_t busy_pin)
+DisplayGDEW075T7::DisplayGDEW075T7(uint8_t spi_bus, uint8_t sck_pin, uint8_t copi_pin, uint8_t cs_pin, uint8_t reset_pin, uint8_t dc_pin, uint8_t busy_pin)
 {
     _spiBus = spi_bus;
     _resetPin = reset_pin;
@@ -226,7 +226,7 @@ DisplayGDEW075T7::DisplayGDEW075T7(uint8_t spi_bus, uint8_t cs_pin, uint8_t rese
     pinMode(_busyPin, INPUT);
 
     _spi = new SPIClass(_spiBus);
-    _spi->begin();
+    _spi->begin(sck_pin, -1, copi_pin, cs_pin);
     _spi->beginTransaction(SPISettings(7000000, MSBFIRST, SPI_MODE0));
     
     _frameBuffer = new uint8_t[FRAMEBUFFER_LENGTH];

--- a/DisplayGDEW075T7.cpp
+++ b/DisplayGDEW075T7.cpp
@@ -214,7 +214,6 @@ DisplayGDEW075T7::~DisplayGDEW075T7() {
 
 DisplayGDEW075T7::DisplayGDEW075T7(uint8_t spi_bus, uint8_t sck_pin, uint8_t copi_pin, uint8_t cs_pin, uint8_t reset_pin, uint8_t dc_pin, uint8_t busy_pin)
 {
-    _spiBus = spi_bus;
     _resetPin = reset_pin;
     _dcPin = dc_pin;
     _csPin = cs_pin;
@@ -225,7 +224,7 @@ DisplayGDEW075T7::DisplayGDEW075T7(uint8_t spi_bus, uint8_t sck_pin, uint8_t cop
     pinMode(_dcPin, OUTPUT);
     pinMode(_busyPin, INPUT);
 
-    _spi = new SPIClass(_spiBus);
+    _spi = new SPIClass(spi_bus);
     _spi->begin(sck_pin, -1, copi_pin, cs_pin);
     _spi->beginTransaction(SPISettings(7000000, MSBFIRST, SPI_MODE0));
     

--- a/DisplayGDEW075T7.h
+++ b/DisplayGDEW075T7.h
@@ -48,7 +48,7 @@ public:
         CENTER          = _ALIGN_HCENTER | _ALIGN_VCENTER,
     };
 
-    DisplayGDEW075T7(uint8_t spi_bus, uint8_t cs_pin, uint8_t reset_pin, uint8_t dc_pin, uint8_t busy_pin);
+    DisplayGDEW075T7(uint8_t spi_bus, uint8_t sck_pin, uint8_t copi_pin, uint8_t cs_pin, uint8_t reset_pin, uint8_t dc_pin, uint8_t busy_pin);
     ~DisplayGDEW075T7();
     void clear(uint8_t color = WHITE);
     void test();

--- a/DisplayGDEW075T7.h
+++ b/DisplayGDEW075T7.h
@@ -88,7 +88,6 @@ public:
     );
  
 private:
-    uint8_t _spiBus;
     uint8_t _resetPin;
     uint8_t _dcPin;
     uint8_t _csPin;

--- a/config.h
+++ b/config.h
@@ -160,10 +160,12 @@
  * Pin assignments
  */
 #define SPI_BUS         HSPI
-#define RESET_PIN       33
-#define DC_PIN          23
-#define CS_PIN          15
-#define BUSY_PIN        27
+#define DIN_PIN         -1 // COPI
+#define CLK_PIN         -1 // SCK
+#define CS_PIN          15 // CS
+#define DC_PIN          23 // Any OUTPUT pin
+#define RESET_PIN       33 // Any OUTPUT pin
+#define BUSY_PIN        27 // Any INPUT pin
 
 /**
  * If debug logs should be printed over serial


### PR DESCRIPTION
I am building this with an ESP32-S2 which does not specify pins at all when HSPI is used (only FSPI)  

Beyond this - SPI pins are generally arbitrary-ish and can be tied to many pins - not just the ones labeled for SPI. 

Toward https://github.com/wuspy/portal_calendar/issues/8