### PR TITLE
Birthdays

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -2,6 +2,10 @@
 #include "global.h"
 #include "time_util.h"
 #include "localization.h"
+#ifdef BIRTHDAYS
+#include "birthday.h"
+Birthday* activeBirthday = nullptr;
+#endif
 
 #include "resources/font/medium.h"
 #include "resources/font/small.h"
@@ -272,6 +276,14 @@ void Display::update(const tm *now, bool showWeather)
     const int year = now->tm_year + 1900;
     const int daysInMonth = getDaysInMonth(now->tm_mon, year);
 
+    bool bdayIcons = false;
+    #ifdef BIRTHDAYS
+        activeBirthday = getBirthday(now->tm_mon+1,now->tm_mday);
+        if(activeBirthday != nullptr){
+          bdayIcons = true;
+        }
+    #endif
+
     // Static lines
     _display->drawHLine(LEFT, 50, WIDTH, 2, DisplayGDEW075T7::BLACK, DisplayGDEW075T7::TOP_LEFT);
     _display->drawHLine(LEFT, 430, WIDTH, 2, DisplayGDEW075T7::BLACK, DisplayGDEW075T7::TOP_LEFT);
@@ -288,9 +300,20 @@ void Display::update(const tm *now, bool showWeather)
     sprintf(buffer, "%02d/%02d", now->tm_mday, daysInMonth);
     _display->drawText(buffer, FONT_MEDIUM, LEFT, 394);
 
-    #ifdef SHOW_DAY
-    // Day name
-    _display->drawText(I18N_DAYS[now->tm_wday], FONT_MEDIUM, RIGHT, 394, DisplayGDEW075T7::TOP_RIGHT);
+    #if defined(SHOW_DAY) || defined(BIRTHDAYS)
+      bool showDay = true;
+      #if defined(BIRTHDAYS) && defined(SHOW_NAME)
+        if (activeBirthday != nullptr && !showWeather){
+          showDay = false;
+          _display->drawText(activeBirthday->name, FONT_MEDIUM, RIGHT, 394, DisplayGDEW075T7::TOP_RIGHT);
+        }
+      #endif  
+      #ifdef SHOW_DAY
+        if(showDay){
+          // Year
+          _display->drawText(I18N_DAYS[now->tm_wday], FONT_MEDIUM, RIGHT, 394, DisplayGDEW075T7::TOP_RIGHT);
+        }
+      #endif
     #endif
 
     #ifdef SHOW_MONTH
@@ -298,10 +321,23 @@ void Display::update(const tm *now, bool showWeather)
     _display->drawText(I18N_MONTHS[now->tm_mon], FONT_MEDIUM, LEFT, 14);
     #endif
 
-    #ifdef SHOW_YEAR
-    // Year
-    sprintf(buffer, "%d", year);
-    _display->drawText(buffer, FONT_MEDIUM, RIGHT, 14, DisplayGDEW075T7::TOP_RIGHT);
+    #if defined(SHOW_YEAR) || defined(BIRTHDAYS)
+      bool showYear = true;
+      #if defined(BIRTHDAYS) && defined(SHOW_AGE)
+        if (activeBirthday != nullptr && !showWeather){
+          showYear = false;
+          byte age = activeBirthday->getAge(year);
+          sprintf(buffer, "%d", age);
+          _display->drawText(buffer, FONT_MEDIUM, RIGHT, 14, DisplayGDEW075T7::TOP_RIGHT);
+        }
+      #endif  
+      #ifdef SHOW_YEAR
+        if(showYear){
+          // Year
+          sprintf(buffer, "%d", year);
+          _display->drawText(buffer, FONT_MEDIUM, RIGHT, 14, DisplayGDEW075T7::TOP_RIGHT);
+        }
+      #endif
     #endif
 
     // Progress bar

--- a/Display.cpp
+++ b/Display.cpp
@@ -370,17 +370,22 @@ void Display::update(const tm *now, bool showWeather)
         #error Invalid value for WEATHER_DISPLAY_TYPE
         #endif // WEATHER_DISPLAY_TYPE
     } else {
-        // Chamber icons
-        if (now->tm_mon == 1 && now->tm_mday == 29) {
-            // Special icon set for leap day
-            for (int i = 0; i < 8; ++i) {
+      // Chamber icons
+        if(bdayIcons){
+            // Special icon set for a birthday
+              for (int i = 0; i < 10; ++i) {
+                drawChamberIcon(IMG_CAKE_ON, i % 5, i / 5);
+              }
+        } else if (now->tm_mon == 1 && now->tm_mday == 29) {
+              // Special icon set for leap day
+              for (int i = 0; i < 8; ++i) {
                 drawChamberIcon(IMG_TURRET_HAZARD_ON, i % 5, i / 5);
-            }
+          }
         } else if (now->tm_mday <= 31) {
-            for (int i = 0; i < 10; ++i) {
-                drawChamberIcon(*CHAMBER_ICON_SETS[now->tm_mday - 1][i], i % 5, i / 5);
-            }
-        }
+              for (int i = 0; i < 10; ++i) {
+                  drawChamberIcon(*CHAMBER_ICON_SETS[now->tm_mday - 1][i], i % 5, i / 5);
+              }
+          }
     }
 
     _display->refresh();

--- a/birthday.h
+++ b/birthday.h
@@ -1,0 +1,53 @@
+#include "config.h"
+/**
+ * Define a struct objec to hold birthday data
+ */
+struct Birthday{
+  Birthday(){};
+  Birthday(byte m, byte d, int y, String n){
+    month = m;
+    day = d;
+    year = y;
+    name = n;
+  }
+  byte month=0;
+  byte day=0;
+  int year=0;
+  String name = "";
+
+  bool isToday(byte m, byte d){
+    return (month == m) && (day == d);
+  }
+
+  byte getAge(int curYear){
+    return curYear - year;
+  }  
+};
+
+Birthday birthday1 =  Birthday(BIRTHDAY_1_MONTH,BIRTHDAY_1_DAY,BIRTHDAY_1_YEAR,BIRTHDAY_1_Name);
+Birthday birthday2 =  Birthday(BIRTHDAY_2_MONTH,BIRTHDAY_2_DAY,BIRTHDAY_2_YEAR,BIRTHDAY_2_Name);
+Birthday birthday3 =  Birthday(BIRTHDAY_3_MONTH,BIRTHDAY_3_DAY,BIRTHDAY_3_YEAR,BIRTHDAY_3_Name);
+Birthday birthday4 =  Birthday(BIRTHDAY_4_MONTH,BIRTHDAY_4_DAY,BIRTHDAY_4_YEAR,BIRTHDAY_4_Name);
+
+
+/**
+ * Check if there are any active birthdays today
+ * and return the first one found
+ */
+Birthday* getBirthday(byte month, byte day){
+  if (birthday1.isToday(month,day)){
+    return &birthday1;
+  }
+  else if(birthday2.isToday(month,day)){
+    return &birthday2;
+  }
+  else if(birthday3.isToday(month,day)){
+    return &birthday3;
+  }
+  else if(birthday4.isToday(month,day)){
+    return &birthday4;
+  }
+  else{
+    return nullptr;
+  }
+}

--- a/config.h
+++ b/config.h
@@ -198,15 +198,18 @@
    * become active.  Max of 4 birthdays are allowed
    * but can be increased by modifying the
    * birthday.h file
+   * 
+   * BIRTDHAY_X_NAME option must be in all capital letteres.
+   * If lower case letters are used, they will not display
+   * correctly.
    */
-  // Example Birthday configuration for Portal 1 release date
-  #define BIRTHDAY_1_MONTH 10
-  #define BIRTHDAY_1_DAY 7
-  #define BIRTHDAY_1_YEAR 2007
-  #define BIRTHDAY_1_Name "PORTAL"
+  #define BIRTHDAY_1_MONTH 0
+  #define BIRTHDAY_1_DAY 0
+  #define BIRTHDAY_1_YEAR 0
+  #define BIRTHDAY_1_Name ""
 
-  #define BIRTHDAY_2_MONTH 5
-  #define BIRTHDAY_2_DAY 31
+  #define BIRTHDAY_2_MONTH 6
+  #define BIRTHDAY_2_DAY 1
   #define BIRTHDAY_2_YEAR 1984
   #define BIRTHDAY_2_Name "CAKE"
 

--- a/config.h
+++ b/config.h
@@ -208,10 +208,10 @@
   #define BIRTHDAY_1_YEAR 0
   #define BIRTHDAY_1_Name ""
 
-  #define BIRTHDAY_2_MONTH 6
-  #define BIRTHDAY_2_DAY 1
-  #define BIRTHDAY_2_YEAR 1984
-  #define BIRTHDAY_2_Name "CAKE"
+  #define BIRTHDAY_2_MONTH 0
+  #define BIRTHDAY_2_DAY 0
+  #define BIRTHDAY_2_YEAR 0
+  #define BIRTHDAY_2_Name ""
 
   #define BIRTHDAY_3_MONTH 0
   #define BIRTHDAY_3_DAY 0

--- a/config.h
+++ b/config.h
@@ -167,6 +167,61 @@
 #define NTP_LOCAL_PORT_START 4242
 #define TIMEZONED_LOCAL_PORT_START 2342
 
+/** 
+ *  Enables if the display will check and display the
+ *  birthday display options.  All icons will show
+ *  as active cakes if there is an active birthday.  
+ *  If weather is enabled, this will override the icon 
+ *  display and birthdays will have no effect unless
+ *  switched to the icon via the boot button.
+ */
+#define BIRTHDAYS
+
+#ifdef BIRTHDAYS
+
+  /**
+   * Shows the current age of the active birthday on the top right.
+   * This will override the SHOW_YEAR option if enabled
+   */
+  #define SHOW_AGE
+
+  /**
+  * Shows the current name of the active birthday on the right
+  * side (next to the XX/XX day)
+  * This will override the SHOW_DAY option if enabled
+  */
+  #define SHOW_NAME
+
+  /**
+   * Define the dates for the birthdays.
+   * Defaults are all zeros which will never
+   * become active.  Max of 4 birthdays are allowed
+   * but can be increased by modifying the
+   * birthday.h file
+   */
+  // Example Birthday configuration for Portal 1 release date
+  #define BIRTHDAY_1_MONTH 10
+  #define BIRTHDAY_1_DAY 7
+  #define BIRTHDAY_1_YEAR 2007
+  #define BIRTHDAY_1_Name "PORTAL"
+
+  #define BIRTHDAY_2_MONTH 5
+  #define BIRTHDAY_2_DAY 31
+  #define BIRTHDAY_2_YEAR 1984
+  #define BIRTHDAY_2_Name "CAKE"
+
+  #define BIRTHDAY_3_MONTH 0
+  #define BIRTHDAY_3_DAY 0
+  #define BIRTHDAY_3_YEAR 0
+  #define BIRTHDAY_3_Name ""
+
+  #define BIRTHDAY_4_MONTH 0
+  #define BIRTHDAY_4_DAY 0
+  #define BIRTHDAY_4_YEAR 0
+  #define BIRTHDAY_4_Name ""
+
+#endif
+
 /**
  * Pin assignments
  */


### PR DESCRIPTION
Added a birthday option where you can configure up to 4 birthdays (can be increased if necessary) to show a special icon set similar to leap years but instead just shows all cakes.  I did my best to keep this as close to the current design and to not veer too far from the portal look and also keep the same style of everything is done from the config.h file.  Here is how it looks with all the options.

An active birthday with the show year option:
![birthday and year](https://github.com/wuspy/portal_calendar/assets/20496220/00a7138f-d14e-4b44-9bad-a5275f8e382a)


An active birthday with the show age option (overwrites year):
![birthday and age](https://github.com/wuspy/portal_calendar/assets/20496220/1f275812-9a37-4785-91bf-a63060e5d9dd)


An active birthday with the show age and name option (overwrites year and weekday):
![birthday age and name](https://github.com/wuspy/portal_calendar/assets/20496220/417d18a0-08a8-498b-9800-b229847946d4)


Back to normal the next day: 
![next day](https://github.com/wuspy/portal_calendar/assets/20496220/96f95706-92ef-44d1-8bcc-d838b16e70e3)


Weather always shows normal as it does not care about birthdays:
![weather and no year](https://github.com/wuspy/portal_calendar/assets/20496220/794b6dfb-772a-42f9-b1ec-de1e2fa7d7f1)

