### PR TITLE
Fix UDP port initialization for NTP and timezoned

### DIFF
--- a/time_util.cpp
+++ b/time_util.cpp
@@ -108,7 +108,7 @@ void advanceDay(int& month, int& mday, int& year)
 
 TimezonedResult getPosixTz(std::initializer_list<const String> servers, const String name, String &result)
 {
-    uint16_t i = TIMEZONED_LOCAL_PORT_START;
+    uint16_t i = 0;
     for (String server : servers) {
         if (server.isEmpty()) {
             continue;
@@ -170,7 +170,7 @@ TimezonedResult getPosixTz(std::initializer_list<const String> servers, const St
  */
 bool syncNtp(std::initializer_list<const String> servers, bool test)
 {
-    uint16_t i = NTP_LOCAL_PORT_START;
+    uint16_t i = 0;
     for (String server : servers) {
         if (server.isEmpty()) {
             continue;


### PR DESCRIPTION
  ## Summary

  Fixes a bug in UDP port initialization that prevented timezoned servers from working.

  ## Changes

  - Fixed `getPosixTz()` and `syncNtp()` to initialize port counter to 0 instead of base port value
  - Previously, timezoned was attempting to bind to port 4684 (2342 + 2342) instead of 2342
  - Similarly, NTP was attempting to bind to port 8484 (4242 + 4242) instead of 4242

  ## Root Cause

  The port counter variable `i` was incorrectly initialized to the base port constant instead of 0, causing the UDP client to calculate the wrong local port when binding.

  ## Why NTP appeared to work but timezoned didn't

  While both had the same bug, timezoned failures were more apparent due to network equipment behavior:

  - Port 8484 (NTP's incorrect port) happens to be the official DNS-over-HTTPS port, which many firewalls/routers allow by default
  - Port 4684 (timezoned's incorrect port) is in the registered port range with no official assignment, making it more likely to be blocked
  - Firewalls like the UDM Pro may have IDS/IPS rules that flag IoT devices using unexpected ports as suspicious and silently drop packets
  - NTP testing may have only used one server, while timezoned tested both, making the failure more obvious

  ## Testing

  - Verified timezoned servers now successfully respond
  - NTP sync continues to work correctly